### PR TITLE
Rick.cobb/configure more like my vbox so restore works

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
     restart: unless-stopped
     image: justifiably/logitechmediaserver
     hostname: newsounds
-    user: 1000:1000 # Try to run as same user as ripper
     ports:
       - "9000:9000"
       - "9090:9090"
@@ -49,14 +48,15 @@ services:
   # card 0: PCH [HDA Intel PCH], device 0: VT2020 Analog [VT2020 Analog]
   # hw:0,0 is card 0, subdevice 0
   #
-  squeezelite:
-    restart: unless-stopped
-    image: aschamberger/squeezelite
-    environment:
-      - PLAYER=LocalSqueeze
-      - OUTPUT_DEVICE=hw:0,0
-    devices:
-      - "/dev/snd/:/dev/snd/"
+#  squeezelite:
+#    restart: unless-stopped
+#    image: aschamberger/squeezelite
+#    hostname: media-player
+#    environment:
+#      - PLAYER=LocalSqueeze
+#      - OUTPUT_DEVICE=hw:0,0
+#    devices:
+#      - "/dev/snd/:/dev/snd/"
   
   
   #
@@ -93,8 +93,8 @@ services:
         context: ./yar
     environment: 
       - CDROM=/dev/sr0
-      - USER_ID=1000
-      - GROUP_ID=1000
+      - USER_ID=${USER} # postencode wants to add by name (useradd and groupadd). Hmm.
+      - GROUP_ID=${USER} # Using ubuntu convention, since this goes to groupadd. Also hmm.
       - LMS_HOST=lms
       - LMS_CLI_PORT=9090
     volumes:
@@ -109,29 +109,29 @@ services:
   # Periodically scans the /flac directory for flac
   # files that don't exist in the target format directories.
   #
-  flac_mirror:
-    restart: unless-stopped
-    user: 1000:1000 # Should run as same user as ripper
-    build:
-        context: ./flac-mirror
-    environment: 
-      # 
-      # A comma seperated list of what formats to mirror to.  
-      # NOTE: make sure that there is an appropriate volume mapped 
-      # for the file type to somewhere outside the container otherwise the
-      # mirrored files will be created inside the container where
-      # no one will be able to see them!
-      #
-      #- MIRROR=M4A
-      - MIRROR=mp3
-      #
-      # ffmpeg mirroring options that can be over-ridden
-      #
-      # - OGG_OPTIONS=-c:a libvorbis
-      # - M4A_OPTIONS=-c:a aac -b:a 192k -vn
-      # - MP3_OPTIONS=-c:a mp3 -ab 192k -map_metadata 0
-    volumes:
-      - /home/${USER}/Music:/flac:ro
-      - /home/${USER}/Music/mp3:/mp3:rw
-      - /home/${USER}/Music/m4a:/m4a:rw
-      - /home/${USER}/Music/ogg:/ogg:rw
+#  flac_mirror:
+#    restart: unless-stopped
+#    user: 1000:1000 # Should run as same user as ripper
+#    build:
+#        context: ./flac-mirror
+#    environment: 
+#      # 
+#      # A comma seperated list of what formats to mirror to.  
+#      # NOTE: make sure that there is an appropriate volume mapped 
+#      # for the file type to somewhere outside the container otherwise the
+#      # mirrored files will be created inside the container where
+#      # no one will be able to see them!
+#      #
+#      #- MIRROR=M4A
+#      - MIRROR=mp3
+#      #
+#      # ffmpeg mirroring options that can be over-ridden
+#      #
+#      # - OGG_OPTIONS=-c:a libvorbis
+#      # - M4A_OPTIONS=-c:a aac -b:a 192k -vn
+#      # - MP3_OPTIONS=-c:a mp3 -ab 192k -map_metadata 0
+#    volumes:
+#      - /home/${USER}/Music:/flac:ro
+#      - /home/${USER}/Music/mp3:/mp3:rw
+#      - /home/${USER}/Music/m4a:/m4a:rw
+#      - /home/${USER}/Music/ogg:/ogg:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,29 +109,34 @@ services:
   # Periodically scans the /flac directory for flac
   # files that don't exist in the target format directories.
   #
-#  flac_mirror:
-#    restart: unless-stopped
-#    user: 1000:1000 # Should run as same user as ripper
-#    build:
-#        context: ./flac-mirror
-#    environment: 
-#      # 
-#      # A comma seperated list of what formats to mirror to.  
-#      # NOTE: make sure that there is an appropriate volume mapped 
-#      # for the file type to somewhere outside the container otherwise the
-#      # mirrored files will be created inside the container where
-#      # no one will be able to see them!
-#      #
-#      #- MIRROR=M4A
-#      - MIRROR=mp3
-#      #
-#      # ffmpeg mirroring options that can be over-ridden
-#      #
-#      # - OGG_OPTIONS=-c:a libvorbis
-#      # - M4A_OPTIONS=-c:a aac -b:a 192k -vn
-#      # - MP3_OPTIONS=-c:a mp3 -ab 192k -map_metadata 0
-#    volumes:
-#      - /home/${USER}/Music:/flac:ro
-#      - /home/${USER}/Music/mp3:/mp3:rw
-#      - /home/${USER}/Music/m4a:/m4a:rw
-#      - /home/${USER}/Music/ogg:/ogg:rw
+  flac_mirror:
+    restart: unless-stopped
+    user: 1000:1000 # Should run as same user as ripper
+    build:
+        context: ./flac-mirror
+    environment: 
+      # 
+      # A comma separated list of what formats to mirror to.  
+      # NOTE: make sure that there is an appropriate volume mapped 
+      # for the file type to somewhere outside the container otherwise the
+      # mirrored files will be created inside the container where
+      # no one will be able to see them!
+      # 
+      # Formats must be capitalized. Current possibilities are
+      #   M4A
+      #   MP3
+      #   OGG
+      #
+      #- MIRROR=M4A
+      - MIRROR=MP3
+      #
+      # ffmpeg mirroring options that can be over-ridden
+      #
+      # - M4A_OPTIONS=-c:a aac -b:a 192k -vn
+      # - MP3_OPTIONS=-c:a mp3 -ab 192k -map_metadata 0
+      # - OGG_OPTIONS=-c:a libvorbis
+    volumes:
+      - /home/${USER}/Music/flac:/flac:ro
+      - /home/${USER}/Music/mp3:/mp3:rw
+      - /home/${USER}/Music/m4a:/m4a:rw
+      - /home/${USER}/Music/ogg:/ogg:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,7 +114,8 @@ services:
       # mirrored files will be created inside the container where
       # no one will be able to see them!
       #
-      - MIRROR=M4A
+      #- MIRROR=M4A
+      - MIRROR=mp3
       #
       # ffmpeg mirroring options that can be over-ridden
       #
@@ -126,4 +127,3 @@ services:
       - /home/${USER}/Music/mp3:/mp3:rw
       - /home/${USER}/Music/m4a:/m4a:rw
       - /home/${USER}/Music/ogg:/ogg:rw
-    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
   lms:
     restart: unless-stopped
     image: justifiably/logitechmediaserver
+    hostname: newsounds
+    user: 1000:1000 # Try to run as same user as ripper
     ports:
       - "9000:9000"
       - "9090:9090"
@@ -22,6 +24,11 @@ services:
       # Use the music files stored in the users Music 
       # directory. Keep all the other related files in there 
       # too.  
+      #
+      # For later: should we mount only flac? Or rely on LMS config to only
+      # use flac? How to handle crap we only have in MP3? IIRC, we already
+      # can configure LMS to only pay attention to flac if there's a pair...
+      # how does it decide on equivalence?
       #
       - /home/${USER}/Music:/mnt/music:ro
       - /home/${USER}/Music/playlists:/mnt/playlists
@@ -104,6 +111,7 @@ services:
   #
   flac_mirror:
     restart: unless-stopped
+    user: 1000:1000 # Should run as same user as ripper
     build:
         context: ./flac-mirror
     environment: 

--- a/flac-mirror/Dockerfile
+++ b/flac-mirror/Dockerfile
@@ -21,4 +21,4 @@ RUN mkdir /flac && \
    mkdir /m4a && \
    mkdir /ogg
 
-ENTRYPOINT ["python", "/mirror.py"]
+ENTRYPOINT ["python", "-u", "/mirror.py"]

--- a/flac-mirror/Dockerfile
+++ b/flac-mirror/Dockerfile
@@ -21,4 +21,4 @@ RUN mkdir /flac && \
    mkdir /m4a && \
    mkdir /ogg
 
-ENTRYPOINT ["python", "-u", "/mirror.py"]
+ENTRYPOINT ["python", "/mirror.py"]

--- a/flac-mirror/mirror.py
+++ b/flac-mirror/mirror.py
@@ -37,7 +37,8 @@ def check_mirror_status(flac_file, mirror_format):
     # ~/Music/flac/Artist-Album/01-track.flac -> Artist-Album/01-track
     #
     rel_name = os.path.relpath(flac_file,  flac_dir)[:-4]
-    
+
+    print(f'Checking flac_file {flac_file} flac_dir {flac_dir} yields rel_name {rel_name}')
     
     #
     # Workout the target mirrored file name.  If it doesn't exist
@@ -47,6 +48,8 @@ def check_mirror_status(flac_file, mirror_format):
     #
     mirror_file_name = os.path.join(mirror_format['DIR'], "{}{}".format(rel_name, mirror_format['EXT'].lower()))
     if not os.path.isfile(mirror_file_name):
+        print(f'mirroring to {mirror_file_name}')
+
         mirror_dir_name = os.path.dirname(mirror_file_name)
         if not os.path.isdir(mirror_dir_name):
             os.makedirs(mirror_dir_name)
@@ -117,6 +120,8 @@ def scan_flac_dir():
 
 
 if __name__ == "__main__":
+    print("Environment:")
+    print(environ)
     #
     # Check what, if any formats are required to be mirrored
     #

--- a/yar/Dockerfile
+++ b/yar/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Get the required extras and clean up
 #
 RUN apt-get update -y && \
-  apt-get install -qy abcde cdparanoia eject flac netcat setcd sdparm eyed3 lame && \
+  apt-get install -qy abcde cdparanoia eject flac netcat setcd sdparm eyed3 lame cd-discid && \
   apt-get remove -qy postfix && \
   apt-get -qy clean && \
   apt-get -qy purge && \

--- a/yar/abcde-local.conf
+++ b/yar/abcde-local.conf
@@ -413,10 +413,10 @@ OUTPUTTYPE=flac
 # Since multiple-output was integrated we always append the file type
 # to the files. Remove it from your user defined string if you are getting
 # files like ".ogg.ogg".
-#OUTPUTFORMAT='${ARTISTFILE}-${ALBUMFILE}/${TRACKNUM}.${TRACKFILE}'
+OUTPUTFORMAT='${ARTISTFILE}/${ALBUMFILE}/${TRACKNUM} - TRACKFILE}'
 
 # Like OUTPUTFORMAT but for Various Artists discs.
-#VAOUTPUTFORMAT='Various-${ALBUMFILE}/${TRACKNUM}.${ARTISTFILE}-${TRACKFILE}'
+VAOUTPUTFORMAT='Assorted/${ALBUMFILE}/${TRACKNUM} ${ARTISTFILE} - ${TRACKFILE}'
 
 # Like OUTPUTFORMAT and VAOUTPUTFORMAT but for the ONEFILE rips.
 #ONETRACKOUTPUTFORMAT=$OUTPUTFORMAT

--- a/yar/abcde-local.conf
+++ b/yar/abcde-local.conf
@@ -617,11 +617,14 @@ post_encode ()
     id -u ${USER_ID} &>/dev/null || useradd ${USER_ID} 
     [ $(getent group ${GROUP_ID}) ] || groupadd ${GROUP_ID}
     
+    # Added '..' to handle artist directory. Only works if you're using
+    # Artist/Album directory structure; pretty bad security bug if you're not
+    # using Artist directories.
     if [ -n "${USER_ID}" ]; then
-        /usr/bin/chown ${USER_ID} . *
+        /usr/bin/chown ${USER_ID} .. . *
     fi
     if [ -n "${GROUP_ID}" ]; then
-        /usr/bin/chgrp ${GROUP_ID} . *
+        /usr/bin/chgrp ${GROUP_ID} .. . *
     fi    
 }
 

--- a/yar/abcde-local.conf
+++ b/yar/abcde-local.conf
@@ -413,7 +413,7 @@ OUTPUTTYPE=flac
 # Since multiple-output was integrated we always append the file type
 # to the files. Remove it from your user defined string if you are getting
 # files like ".ogg.ogg".
-OUTPUTFORMAT='${ARTISTFILE}/${ALBUMFILE}/${TRACKNUM} - TRACKFILE}'
+OUTPUTFORMAT='${ARTISTFILE}/${ALBUMFILE}/${TRACKNUM} - ${TRACKFILE}'
 
 # Like OUTPUTFORMAT but for Various Artists discs.
 VAOUTPUTFORMAT='Assorted/${ALBUMFILE}/${TRACKNUM} ${ARTISTFILE} - ${TRACKFILE}'

--- a/yar/abcde-local.conf
+++ b/yar/abcde-local.conf
@@ -390,7 +390,7 @@ ACTIONS=cddb,read,encode,tag,getalbumart,embedalbumart,move,clean
 # If you'd like to make a default location that overrides the current
 # directory for putting mp3's, uncomment this.
 #OUTPUTDIR=`pwd`
-OUTPUTDIR=/out
+OUTPUTDIR=/out/flac
 
 # Or if you'd just like to put the temporary .wav files somewhere else
 # you can specify that here

--- a/yar/abcde-local.conf
+++ b/yar/abcde-local.conf
@@ -481,10 +481,10 @@ VAOUTPUTFORMAT='Assorted/${ALBUMFILE}/${TRACKNUM} ${ARTISTFILE} - ${TRACKFILE}'
 # 3. Delete a grab bag of characters which variously Windows and Linux do not permit 
 #   (tr command). Remove any of these from the list if you wish to actually use them.
 #   
-#mungefilename ()
-#{
-#	echo "$@" | sed -e 's/^\.*//' -e 's/ /_/g' | tr -d ":><|*/\"'?[:cntrl:]"
-#}
+mungefilename ()
+{
+	echo "$@" | sed -e 's/^\.*//' | tr -d ":><|*/\"'?[:cntrl:]"
+}
 #
 # More examples for custom filename munging:
 #

--- a/yar/yar.sh
+++ b/yar/yar.sh
@@ -54,15 +54,13 @@ while true; do
 	# From a workflow standpoint, it might be better to just use datetime;
 	# I stack my CDs in the order I rip, so being able to sort by time
 	# might work better when tagging. But since LMS/New Music sorts that
-	# way anyway, let's go with a clean key. Since we've inherited
-	# underscores munge the id to replace spaces with underscores. Do I
-	# really want underscores?  I didn't have them in vbox.
+	# way anyway, let's go with a clean key. 
 	#
-	# Don't have a clean way to make this respond to custom munge...
+	# Don't have a clean way to make this respond to custom munge<whatever>
 	# functions in abcde.conf. Hmm.
 	dest_dir="/out/flac"
 	if [ -d "${dest_dir}/Unknown_Artist/Unknown_Album" ]; then
-	    disc_id=$(cd-discid /dev/sr0 | tr ' ' '_')
+	    disc_id=$(cd-discid /dev/sr0 | cut -d' ' -f1)
 	    cd "${dest_dir}"
 	    mv "Unknown_Artist/Unknown_Album" "Unknown_Artist/Unknown_Album_$disc_id"
 	    cd "${OLDPWD}"

--- a/yar/yar.sh
+++ b/yar/yar.sh
@@ -53,17 +53,18 @@ while true; do
 	#
 	# From a workflow standpoint, it might be better to just use datetime;
 	# I stack my CDs in the order I rip, so being able to sort by time
-	# might work better when tagging. But since LMS/New Music sorts that
-	# way anyway, let's go with a clean key. 
+	# might work better when tagging a batch. But since LMS/New Music sorts
+	# that way anyway, let's go with a clean key. 
 	#
 	# Don't have a clean way to make this respond to custom munge<whatever>
-	# functions in abcde.conf. Hmm.
-	dest_dir="/out/flac"
-	if [ -d "${dest_dir}/Unknown_Artist/Unknown_Album" ]; then
+	# functions in abcde.conf, so if you don't like spaces in filenames,
+	# you'll need to change the unknown_album value here to match what your
+	# abcde.conf says.
+	flac_root_fullpath="/out/flac"
+	unknown_album="Unknown Artist/Unknown Album"
+	if [ -d "${flac_root_fullpath}/${unknown_album}" ]; then
 	    disc_id=$(cd-discid /dev/sr0 | cut -d' ' -f1)
-	    cd "${dest_dir}"
-	    mv "Unknown_Artist/Unknown_Album" "Unknown_Artist/Unknown_Album_$disc_id"
-	    cd "${OLDPWD}"
+	    mv "${flac_root_fullpath}/${unknown_album}" "${flac_root_fullpath}/${unknown_album}_${disc_id}"
 	fi
         
         #

--- a/yar/yar.sh
+++ b/yar/yar.sh
@@ -41,6 +41,32 @@ while true; do
         #
         #
         /usr/bin/abcde -N -d ${CDROM} -o flac -c /etc/abcde-local.conf
+
+	# If it couldn't find the album in CDDB (or whatever's configured
+	# in abcde-local.conf), it'll create an Unknown_Artist/Unkown_Album directory.
+	# Then the *next one* like that will overwrite files in there.
+	# So move it to someplace unique.  The pattern match here is intended
+	# to support both my convention (directory per artist) and the default.
+	#
+	# It's handy that we haven't been able to eject yet :)
+	# Taken from https://unix.stackexchange.com/a/287851
+	#
+	# From a workflow standpoint, it might be better to just use datetime;
+	# I stack my CDs in the order I rip, so being able to sort by time
+	# might work better when tagging. But since LMS/New Music sorts that
+	# way anyway, let's go with a clean key. Since we've inherited
+	# underscores munge the id to replace spaces with underscores. Do I
+	# really want underscores?  I didn't have them in vbox.
+	#
+	# Don't have a clean way to make this respond to custom munge...
+	# functions in abcde.conf. Hmm.
+	dest_dir="/out/flac"
+	if [ -d "${dest_dir}/Unknown_Artist/Unknown_Album" ]; then
+	    disc_id=$(cd-discid /dev/sr0 | tr ' ' '_')
+	    cd "${dest_dir}"
+	    mv "Unknown_Artist/Unknown_Album" "Unknown_Artist/Unknown_Album_$disc_id"
+	    cd "${OLDPWD}"
+	fi
         
         #
         # Tell LMS to rescan the library to pick-up these new files


### PR DESCRIPTION
This makes several significant changes in VBR:
1. Uses "artist directory with spaces"/"album name directory with spaces"/"Number - song name with spaces.type"
2. Rips to Music/flac instead of Music/
3. Successfully mirrors from Music/flac to Music/mp3 
4. Configures LMS with name "newsounds"
5. Starts down the road of getting gids / uids aligned (file separate personal-fork issue)
6. Uses my crazy convention of naming the "Various Artists" folder "Assorted"; I find that easier to find in alphabetic lists, and my collection has a *lot* of compilations in it.
7. Logs a lot more when doing flac mirroring; I needed that when things weren't working, but may back it off (or install python's logger and add command line or env var control).