### PR TITLE
LMS: stable Music mounts (MUSIC_ROOT), docs, and Cursor PR rule

### DIFF
--- a/.cursor/rules/pr-and-merge.mdc
+++ b/.cursor/rules/pr-and-merge.mdc
@@ -1,0 +1,11 @@
+---
+description: GitHub PR workflow; when to nudge the user vs merge
+alwaysApply: true
+---
+
+# Pull requests and merging
+
+- We use **PR discipline** for changes that should land on `master` (branch protection may require it).
+- After pushing a feature branch, it is **OK** to tell the user clearly: the PR (or ready-to-PR work) is on GitHub—**go to the repo, review, and merge** (or open the PR if it is not open yet). Do not assume the user has time to run `gh` or wants automation every time.
+- The user can **anytime** say to go ahead and merge (with or without their review, or to merge on their behalf if tooling allows). If they say to merge, use normal Git/GitHub flow (`gh pr merge`, or instructions they follow on the web) without asking again for the same permission.
+- If `gh` is not available, authenticated, or suitable, default to **“here is the link / branch name; merge on GitHub”** rather than blocking on automation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,15 @@
 
 - **Where we run things:** We do **not** run the stack locally. We keep the source here and use **newsounds for all testing** (deploy there, run `docker compose` there, verify there).
 
-- **Workflow:** We keep the source in this repo and make changes via **GitHub pushes and branches**. When we start a new effort (e.g. a bug fix or feature), we start a new branch for it. Once it works on newsounds, we merge to master.
+- **Workflow:** We keep the source in this repo and make changes via **GitHub pushes and branches**. When we start a new effort (e.g. a bug fix or feature), we start a **new branch** for it. When it works on newsounds, we **merge into `master` via a pull request** on GitHub (do not push directly to `master`; it is branch-protected).
+
+- **Repository:** The canonical remote is **`origin`** (`cobbr2/VBR`). That is our fork’s `master`, not “someone else’s” upstream; changes land on our `master` through PRs here. If we add an `upstream` remote later, treat it as read-only unless we intend to contribute back.
+
+- **Branch discipline**
+    - **Naming:** Prefer `issue/<short-slug>` for bug fixes and targeted work, `feature/<short-slug>` for larger features (e.g. `issue/lms-loses-state`). Keep slugs short and stable.
+    - **One branch per effort** so history and review stay clear. Push the branch to `origin`, open a PR into `master`, merge on GitHub when done.
+    - **Why there are many branches:** Past work (Samba experiments, permissions, sync-file issues, etc.) each got its own branch; that is normal. **After a PR is merged**, delete the branch on GitHub and remove the local copy (`git branch -d <branch>`) so the list stays manageable. Branches that were abandoned without merging can stay until we either finish them or delete them deliberately.
+    - **Optional cleanup:** Periodically `git fetch --prune origin` and review `git branch -a` for stale names.
 
 - **Target client:** The Mac we need to connect is the highest priority: **rick-laptop24**. It runs Tahoe 26.3.1 and is M2-based.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,9 @@
 
 - **SSH:** You can ssh to `newsounds` (or, when needed, `sounds`) directly without a password to check docker status and run commands.
 
-- **Workflow:** We use branches for new features. Once a feature works, we merge to master.
+- **Where we run things:** We do **not** run the stack locally. We keep the source here and use **newsounds for all testing** (deploy there, run `docker compose` there, verify there).
+
+- **Workflow:** We keep the source in this repo and make changes via **GitHub pushes and branches**. When we start a new effort (e.g. a bug fix or feature), we start a new branch for it. Once it works on newsounds, we merge to master.
 
 - **Target client:** The Mac we need to connect is the highest priority: **rick-laptop24**. It runs Tahoe 26.3.1 and is M2-based.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,9 +29,9 @@ services:
       # can configure LMS to only pay attention to flac if there's a pair...
       # how does it decide on equivalence?
       #
-      - /home/${USER}/Music:/mnt/music:ro
-      - /home/${USER}/Music/playlists:/mnt/playlists
-      - /home/${USER}/Music/state:/mnt/state
+      - ${MUSIC_ROOT:-/home/rec/Music}:/mnt/music:ro
+      - ${MUSIC_ROOT:-/home/rec/Music}/playlists:/mnt/playlists
+      - ${MUSIC_ROOT:-/home/rec/Music}/state:/mnt/state
       
       
   #
@@ -66,7 +66,7 @@ services:
   # inserted audio disks.
   #
   # The ripper's /out directory is mapped to the same directory
-  # that LMS looks in for media, i.e. /home/${USER}/Music
+  # that LMS looks in for media, i.e. ${MUSIC_ROOT:-/home/rec/Music}
   #
   # Note, need to give the ripper container access to the
   # CDROM device and then tell it what device to use.
@@ -94,7 +94,7 @@ services:
       - LMS_HOST=lms
       - LMS_CLI_PORT=9090
     volumes:
-      - /home/${USER}/Music:/out:rw
+      - ${MUSIC_ROOT:-/home/rec/Music}:/out:rw
     devices:
       - "/dev/sr0:/dev/sr0"
       
@@ -132,10 +132,10 @@ services:
       # - MP3_OPTIONS=-c:a mp3 -ab 192k -map_metadata 0
       # - OGG_OPTIONS=-c:a libvorbis
     volumes:
-      - /home/${USER}/Music/flac:/flac:ro
-      - /home/${USER}/Music/mp3:/mp3:rw
-      - /home/${USER}/Music/m4a:/m4a:rw
-      - /home/${USER}/Music/ogg:/ogg:rw
+      - ${MUSIC_ROOT:-/home/rec/Music}/flac:/flac:ro
+      - ${MUSIC_ROOT:-/home/rec/Music}/mp3:/mp3:rw
+      - ${MUSIC_ROOT:-/home/rec/Music}/m4a:/m4a:rw
+      - ${MUSIC_ROOT:-/home/rec/Music}/ogg:/ogg:rw
   #
   # Samba: Music share for Mac/Windows clients (e.g. Picard). Uses same
   # Music dir as LMS/ripper; force user 1000 so files are owned by rec on host.
@@ -157,7 +157,7 @@ services:
   #     - ACCOUNT_nobody=65534:guest
   #   volumes:
   #     - ./samba/smb.conf:/etc/samba/smb.conf:ro
-  #     - /home/${USER}/Music:/music:rw
+  #     - ${MUSIC_ROOT:-/home/rec/Music}:/music:rw
   #   tmpfs:
   #     - /run/samba
   #   hostname: newsounds

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,31 +100,10 @@ services:
       
 
   #
-  # Mirror flac files to the spcified formats.
+  # Mirror flac files to the specified formats.
   #
   # Periodically scans the /flac directory for flac
   # files that don't exist in the target format directories.
-  #
-  #
-  # Samba: Music share for Mac/Windows clients (e.g. Picard). Uses same
-  # Music dir as LMS/ripper; force user 1000 so files are owned by rec on host.
-  #
-  samba:
-    restart: unless-stopped
-    build:
-      context: ./samba
-    ports:
-      - "139:139"
-      - "445:445"
-      - "137:137/udp"
-      - "138:138/udp"
-    volumes:
-      - /home/${USER}/Music:/music:rw
-    # Optional: match hostname so SMB appears as same host as LMS
-    hostname: newsounds
-
-  #
-  # Mirror flac files to the spcified formats.
   #
   flac_mirror:
     restart: unless-stopped


### PR DESCRIPTION
## Summary

Fix Docker Compose so LMS, ripper, and flac\_mirror always bind to the same host music tree, regardless of shell `USER` (e.g. `sudo` / root). Add workflow notes and a Cursor rule for how we handle PRs.

## Primarily to address https://github.com/cobbr2/VBR/issues/12

## Changes

- **`docker-compose.yml`:** Replace `/home/${USER}/Music` with a single DRY value: ``${MUSIC_ROOT:-/home/rec/Music}`` for all volume paths (LMS, ripper, flac mirror, and the commented Samba example). The default keeps production on `newsounds` as `/home/rec/Music` no matter who runs `docker compose`.
    * Also removes the samba section.  Extensive experimentation never got it working.
- **`AGENTS.md`:** Test only on `newsounds`, branch per effort, merge to `master` via GitHub PR; branch naming, why old branches pile up, cleanup; this fork is `origin` (cobbr2/VBR).
- **`.cursor/rules/pr-and-merge.mdc`:** Always apply — PR workflow; it’s fine to nudge a human to review/merge on GitHub; the user can tell the agent to merge without re-asking.

## Tested

- **newsounds:** Pulled and deployed; compose recreated LMS / ripper / flac\_mirror. Post-check: same favorites (6), same `library.db` row counts, same plugin pref file count, mounts still ` /home/rec/Music/...` — no state regression.

## After merge (optional)

- [ ] Delete branch `issue/lms-loses-state` on GitHub and `git branch -d` locally.
```

If you install **`gh`** and `gh auth login`, next time we can run `gh pr create` and skip the copy-paste step. If you add a **`GITHUB_TOKEN`** to the environment (repo scope), the API can open PRs the same way.