### PR TITLE
Ripper & flac-mirror: dirty discs, mirror resilience, transcode errors, extra_hosts

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+USER=rec

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@
 
 - **Samba in Docker:** Containerized Samba (custom or mbentley image) currently fails with NT_STATUS_NO_SUCH_USER on tree connect (auth succeeds). Use **host Samba** with `host_samba/smb.conf` as the working approach until that is resolved. See `samba/README.md`.
 
+- **Cron hygiene:** `newsounds` currently has a `rec` crontab entry for `/home/rec/scripts/docker_cleanup.sh`, but that path/script does not exist. Treat this as stale until we either add a real script or remove the crontab line.
+
 - **Goals** 
     - Run "newsounds" as the primary LMS server / ripper / mirror on our network.
     - Also have it serve filesystems that allow editing the music collection.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+COMPOSE_BASE = docker compose -f docker-compose.yml
+COMPOSE_TEST = docker compose -f docker-compose.yml -f docker-compose.test.yml
+
+.PHONY: verify-test-override test-config test-up test-restart test-ps test-logs
+
+verify-test-override:
+	python3 tools/verify_test_override.py
+
+test-config: verify-test-override
+	$(COMPOSE_TEST) config
+
+test-up: verify-test-override
+	$(COMPOSE_TEST) up -d
+
+test-restart: verify-test-override
+	$(COMPOSE_TEST) up -d --force-recreate ripper flac_mirror
+
+test-ps: verify-test-override
+	$(COMPOSE_TEST) ps
+
+test-logs: verify-test-override
+	$(COMPOSE_TEST) logs --tail=100 ripper flac_mirror

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  # Test override: keep production compose untouched and redirect
+  # ripper/mirror media paths to TEST_MUSIC_ROOT.
+  # Intentionally does NOT override LMS volumes.
+
+  ripper:
+    volumes:
+      - ${TEST_MUSIC_ROOT:-/home/rec/Music_test}:/out:rw
+
+  flac_mirror:
+    volumes:
+      - ${TEST_MUSIC_ROOT:-/home/rec/Music_test}/flac:/flac:ro
+      - ${TEST_MUSIC_ROOT:-/home/rec/Music_test}/mp3:/mp3:rw
+      - ${TEST_MUSIC_ROOT:-/home/rec/Music_test}/m4a:/m4a:rw
+      - ${TEST_MUSIC_ROOT:-/home/rec/Music_test}/ogg:/ogg:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,13 +75,16 @@ services:
   # chowns ripped files to USER_ID:GROUP_ID (1000:1000 = rec on host) so Samba
   # and Mac clients (e.g. Picard) can read/write/delete without a separate chown.
   #
-  # The LMS_HOST (i.e the service name above) and LMS_PORT are 
+  # The LMS_HOST and LMS_PORT from above can be 
   # used by the ripper to be able to contact LMS and tell it 
   # to rescan the contents of /mnt/music so that the newly 
   # ripped files are detected and indexed.  If the server 
   # cannot be found, it silently times out and LMS won't know 
   # about the new files unless the use through the UI initiates
   # a rescan.
+  #
+  # OTOH: since our LMS_HOST is in "host" network_mode, the name
+  # "lms" won't find it. Thus the "extra_hosts" entry. 
   #
   ripper:
     restart: unless-stopped
@@ -97,6 +100,8 @@ services:
       - ${MUSIC_ROOT:-/home/rec/Music}:/out:rw
     devices:
       - "/dev/sr0:/dev/sr0"
+    extra_hosts:
+      - "lms:host-gateway"
       
 
   #

--- a/docs/ripper-mirror-test-plan.md
+++ b/docs/ripper-mirror-test-plan.md
@@ -1,0 +1,99 @@
+# Ripper + Mirror Test Plan (newsounds)
+
+Scope: validate `ripper` and `flac_mirror` behavior safely, without polluting production media paths.
+
+Rules:
+- Run tests on `newsounds` only.
+- Keep LMS on normal config; test override applies only to `ripper` and `flac_mirror`.
+- Use `TEST_MUSIC_ROOT` (default `/home/rec/Music_test`) for test outputs.
+
+## 1) Pre-flight
+
+- [ ] Confirm branch/commit on `newsounds` (`git rev-parse --short HEAD`).
+- [ ] Confirm test override guard passes:
+  - `python3 tools/verify_test_override.py`
+- [ ] Ensure test root exists:
+  - `/home/rec/Music_test/{flac,mp3,m4a,ogg,playlists,state}`
+- [ ] Stop production `ripper`/`flac_mirror` before test run (avoid `/dev/sr0` contention):
+  - `docker compose stop ripper flac_mirror`
+
+## 2) Start test-mode services
+
+- [ ] Start test-mode `ripper` and `flac_mirror`:
+  - `TEST_MUSIC_ROOT=/home/rec/Music_test docker compose -f docker-compose.yml -f docker-compose.test.yml up -d ripper flac_mirror`
+- [ ] Verify binds:
+  - `ripper` binds `/home/rec/Music_test:/out`
+  - `flac_mirror` binds `/home/rec/Music_test/flac -> /flac`, `/mp3`, `/m4a`, `/ogg`
+
+## 3) Known-good disc test
+
+Use one already-ripped, known-good CD.
+
+- [ ] Insert disc and watch logs:
+  - `docker compose logs --tail=200 -f ripper flac_mirror`
+- [ ] Confirm FLAC output appears under `/home/rec/Music_test/flac/...`.
+- [ ] Confirm mirrored MP3 output appears under `/home/rec/Music_test/mp3/...`.
+- [ ] Confirm no crashes/restart loops for either container.
+- [ ] Confirm logs are readable (not silent, not overwhelming spam).
+
+## 4) Repeatability / idempotence check
+
+- [ ] Re-run with the same known-good disc.
+- [ ] Verify no unexpected duplicate explosions in test directories.
+- [ ] Verify mirror does not continuously re-transcode unchanged inputs.
+
+## 5) Error-path checks (optional, recommended)
+
+- [ ] Use a problematic/dirty disc and verify ripper behavior is explicit.
+- [ ] Confirm transcode failure logs are specific enough to diagnose track/file.
+- [ ] Confirm mirror continues processing other files when one fails.
+
+## 6) Non-regression checks for LMS state safety
+
+These checks guard against collateral LMS regressions while testing ripper/mirror.
+
+- [ ] LMS mounts still point to production music/state (`/home/rec/Music...`).
+- [ ] Favorites count/list unchanged from baseline.
+- [ ] Library DB counts unchanged unless intentionally rescanned.
+- [ ] Plugin prefs count unchanged.
+
+## 7) Exit / cleanup
+
+- [ ] Stop test-mode `ripper`/`flac_mirror`:
+  - `TEST_MUSIC_ROOT=/home/rec/Music_test docker compose -f docker-compose.yml -f docker-compose.test.yml stop ripper flac_mirror`
+- [ ] Restart normal production `ripper`/`flac_mirror`:
+  - `docker compose up -d ripper flac_mirror`
+- [ ] Optionally clean test artifacts from `/home/rec/Music_test`.
+
+## Useful commands
+
+```bash
+# Guard
+python3 tools/verify_test_override.py
+
+# Start test mode
+TEST_MUSIC_ROOT=/home/rec/Music_test docker compose -f docker-compose.yml -f docker-compose.test.yml up -d ripper flac_mirror
+
+# Observe
+TEST_MUSIC_ROOT=/home/rec/Music_test docker compose -f docker-compose.yml -f docker-compose.test.yml ps
+TEST_MUSIC_ROOT=/home/rec/Music_test docker compose -f docker-compose.yml -f docker-compose.test.yml logs --tail=200 -f ripper flac_mirror
+
+# Stop test mode
+TEST_MUSIC_ROOT=/home/rec/Music_test docker compose -f docker-compose.yml -f docker-compose.test.yml stop ripper flac_mirror
+```
+
+## Tonight stop criteria (2026-04-26)
+
+If the known-good CD test succeeds in test mode, stop for tonight and defer Spotty:
+
+- [ ] `ripper` and `flac_mirror` run cleanly against `TEST_MUSIC_ROOT` (`/home/rec/Music_test`).
+- [ ] FLAC output appears in test tree, and MP3 mirror output appears as expected.
+- [ ] No unexpected duplicate explosion in test output for this run.
+- [ ] No stall/restart loop; logs are readable and actionable.
+- [ ] Production LMS state remains unchanged (favorites/library/plugin baseline intact).
+
+After these pass:
+- [ ] Merge current ripper/mirror work.
+- [ ] Next effort: LMS/Lyrion upgrade.
+- [ ] Future effort after upgrade: orphan-prune + marker-file feature.
+

--- a/flac-mirror/mirror.py
+++ b/flac-mirror/mirror.py
@@ -11,6 +11,18 @@ import subprocess
 # Track files that have failed during this container's uptime
 FAILED_FILES = set()
 
+def try_copy_owner_mode(target_path, source_path, kind):
+    """Best-effort chmod/chown: warn and continue on permission issues."""
+    try:
+        st = os.stat(source_path)
+        os.chown(target_path, st.st_uid, st.st_gid)
+        os.chmod(target_path, st.st_mode & 0o777)
+    except PermissionError as exc:
+        print(f"!!! WARN: could not align {kind} ownership/mode for {target_path}: {exc}", file=sys.stderr, flush=True)
+    except FileNotFoundError:
+        # Source or target disappeared during processing; allow next scan loop to retry.
+        print(f"!!! WARN: skipped {kind} ownership/mode alignment because file vanished: {target_path}", file=sys.stderr, flush=True)
+
 def check_mirror_status(flac_file, mirror_format):
     # 1. Ignore Apple/System metadata immediately
     if os.path.basename(flac_file).startswith('._'):
@@ -30,8 +42,7 @@ def check_mirror_status(flac_file, mirror_format):
         if not os.path.isdir(mirror_dir_name):
             os.makedirs(mirror_dir_name, exist_ok=True)
             flac_file_dir = os.path.dirname(os.path.abspath(flac_file))
-            os.chown(mirror_dir_name, os.stat(flac_file_dir).st_uid, os.stat(flac_file_dir).st_gid)
-            os.chmod(mirror_dir_name, os.stat(flac_file_dir).st_mode & 0o777)
+            try_copy_owner_mode(mirror_dir_name, flac_file_dir, 'directory')
 
         mirror_command = ['/usr/bin/ffmpeg', '-hide_banner', '-loglevel', 'error', '-i', flac_file]
         mirror_command = mirror_command + mirror_format['OPTIONS']
@@ -41,8 +52,7 @@ def check_mirror_status(flac_file, mirror_format):
 
         if result.returncode == 0:
             if os.path.isfile(mirror_file_name):
-                os.chown(mirror_file_name, os.stat(flac_file).st_uid, os.stat(flac_file).st_gid)
-                os.chmod(mirror_file_name, os.stat(flac_file).st_mode & 0o777)
+                try_copy_owner_mode(mirror_file_name, flac_file, 'file')
             print(f'Completed: {rel_name}', flush=True)
             return 'MIRRORED'
         else:

--- a/flac-mirror/mirror.py
+++ b/flac-mirror/mirror.py
@@ -8,27 +8,31 @@ from os import walk
 import time
 import subprocess
 
+# Track files that have failed during this container's uptime
+FAILED_FILES = set()
+
 def check_mirror_status(flac_file, mirror_format):
-    # Ignore macOS metadata files
+    # 1. Ignore Apple/System metadata immediately
     if os.path.basename(flac_file).startswith('._'):
         return 'IGNORED'
+    
+    # 2. Check if we've already given up on this file this session
+    if flac_file in FAILED_FILES:
+        return 'PERSISTENT_ERROR'
 
-    # .flac is 5 characters
     rel_name = os.path.relpath(flac_file, flac_dir)[:-5]
-
     mirror_file_name = os.path.join(mirror_format['DIR'], "{}.{}".format(rel_name, mirror_format['EXT'].lower()))
     
     if not os.path.isfile(mirror_file_name):
-        print(f'Mirroring: {rel_name}.flac -> {mirror_format["EXT"]}')
+        print(f'Mirroring: {rel_name}.flac -> {mirror_format["EXT"]}', flush=True)
 
         mirror_dir_name = os.path.dirname(mirror_file_name)
         if not os.path.isdir(mirror_dir_name):
-            os.makedirs(mirror_dir_name)
+            os.makedirs(mirror_dir_name, exist_ok=True)
             flac_file_dir = os.path.dirname(os.path.abspath(flac_file))
             os.chown(mirror_dir_name, os.stat(flac_file_dir).st_uid, os.stat(flac_file_dir).st_gid)
             os.chmod(mirror_dir_name, os.stat(flac_file_dir).st_mode & 0o777)
 
-        # Added -hide_banner and -loglevel error
         mirror_command = ['/usr/bin/ffmpeg', '-hide_banner', '-loglevel', 'error', '-i', flac_file]
         mirror_command = mirror_command + mirror_format['OPTIONS']
         mirror_command.append(mirror_file_name)
@@ -39,11 +43,15 @@ def check_mirror_status(flac_file, mirror_format):
             if os.path.isfile(mirror_file_name):
                 os.chown(mirror_file_name, os.stat(flac_file).st_uid, os.stat(flac_file).st_gid)
                 os.chmod(mirror_file_name, os.stat(flac_file).st_mode & 0o777)
+            print(f'Completed: {rel_name}', flush=True)
             return 'MIRRORED'
         else:
-            print(f"Error creating {mirror_file_name}", file=sys.stderr)
+            # LOUD LOGGING for actual failures
+            print(f"!!! ERROR: Failed to transcode {flac_file}", file=sys.stderr, flush=True)
             if result.stderr:
-                print(result.stderr.decode(), file=sys.stderr)
+                print(f"!!! FFMPEG STDERR: {result.stderr.decode()}", file=sys.stderr, flush=True)
+            
+            FAILED_FILES.add(flac_file)
             return 'ERROR'
 
     return 'EXISTS'
@@ -52,7 +60,6 @@ def scan_flac_dir():
     counts = {'FLAC': 0}
     start_time = time.time()
     for (dirpath, dirnames, filenames) in walk(flac_dir):
-        # Skip hidden directories
         dirnames[:] = [d for d in dirnames if not d.startswith('.')]
         for f in filenames:
             if f.endswith('.flac') and not f.startswith('._'):
@@ -64,16 +71,19 @@ def scan_flac_dir():
                     cc = f"{mirror_format}_{rc}"
                     counts[cc] = counts.get(cc, 0) + 1
 
-    # Clean Heartbeat Output
-    tasks = [f"{m}: {counts.get(m+'_MIRRORED',0)} new, {counts.get(m+'_ERROR',0)} err" for m in mirror_formats]
-    print(f"Heartbeat: Scanned {counts['FLAC']} files in {time.time() - start_time:.2f}s. Tasks: {', '.join(tasks)}", flush=True)
+    # Format the task summary
+    tasks = []
+    for m in mirror_formats:
+        new = counts.get(f"{m}_MIRRORED", 0)
+        err = counts.get(f"{m}_ERROR", 0)
+        tasks.append(f"{m}: {new} new, {err} fail")
+
+    # Final heartbeat line
+    log_msg = f"Heartbeat: {counts['FLAC']} total FLACs | {len(FAILED_FILES)} skipped (errors) | {', '.join(tasks)}"
+    print(log_msg, flush=True)
 
 if __name__ == "__main__":
     mirror_formats = [m for m in environ.get('MIRROR', '').strip().split(',') if m]
-    if not mirror_formats:
-        print("No formats to mirror specified", flush=True)
-        sys.exit(1)
-
     flac_dir = environ.get('FLAC_DIR', '/flac')
     
     format_options = {
@@ -84,18 +94,12 @@ if __name__ == "__main__":
 
     for fmat in mirror_formats:
         if fmat in format_options:
-            ev_dir = f"{fmat}_DIR"
-            if ev_dir in environ:
-                format_options[fmat]['DIR'] = environ[ev_dir]
-            
-            ev_opt = f"{fmat}_OPTIONS"
-            if ev_opt in environ:
-                format_options[fmat]['OPTIONS'] = environ[ev_opt]
-            
+            ev_dir, ev_opt = f"{fmat}_DIR", f"{fmat}_OPTIONS"
+            if ev_dir in environ: format_options[fmat]['DIR'] = environ[ev_dir]
+            if ev_opt in environ: format_options[fmat]['OPTIONS'] = environ[ev_opt]
             format_options[fmat]['OPTIONS'] = format_options[fmat]['OPTIONS'].split()
 
-    print(f"flac-mirror started for formats: {', '.join(mirror_formats)}", flush=True)
-
+    print(f"flac-mirror logic updated. Persistent errors will be logged with '!!!'.", flush=True)
     while True:
         scan_flac_dir()
         time.sleep(60)

--- a/flac-mirror/mirror.py
+++ b/flac-mirror/mirror.py
@@ -1,25 +1,6 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
-#
-# Mirror flac files to other formats.
-#
-# Files in FLAC_DIR are scanned to check if they have a 
-# corresponding mirrored version in the other format *_DIR 
-# directory.  If *_DIR is not set for a format then the FLAC_DIR
-# is used.
-#
-# Supported target formats are:
-#   OGG
-#   M4A
-#   MP3
-#
-# The selected formats to mirror are set with the environment 
-# variable MIRROR, e.g. MIRROR=MP3,OGG
-#
-# The ffmpeg conversation options can be over-ridden here to 
-# change the quality etc. e.g MP3_OPTIONS=....
-#
 from os import environ
 import os.path
 import sys
@@ -27,189 +8,94 @@ from os import walk
 import time
 import subprocess
 
-#
-# Check that the mirrored format exists for the flac file.  If
-# not use ffmpeg to create a version of the required format.
-#
 def check_mirror_status(flac_file, mirror_format):
-    #
-    # Get the relative name of the file, e.g. 
-    # ~/Music/flac/Artist-Album/01-track.flac -> Artist-Album/01-track
-    #
-    rel_name = os.path.relpath(flac_file,  flac_dir)[:-4]
+    # Ignore macOS metadata files
+    if os.path.basename(flac_file).startswith('._'):
+        return 'IGNORED'
 
-    print(f'Checking flac_file {flac_file} flac_dir {flac_dir} yields rel_name {rel_name}')
+    # .flac is 5 characters
+    rel_name = os.path.relpath(flac_file, flac_dir)[:-5]
+
+    mirror_file_name = os.path.join(mirror_format['DIR'], "{}.{}".format(rel_name, mirror_format['EXT'].lower()))
     
-    #
-    # Workout the target mirrored file name.  If it doesn't exist
-    # then make sure the target directory exists first.
-    #
-    # e.g Artist-Album/01-track -> ~/Music/mp3/Artist-Album/01-track.mp3
-    #
-    mirror_file_name = os.path.join(mirror_format['DIR'], "{}{}".format(rel_name, mirror_format['EXT'].lower()))
     if not os.path.isfile(mirror_file_name):
-        print(f'mirroring to {mirror_file_name}')
+        print(f'Mirroring: {rel_name}.flac -> {mirror_format["EXT"]}')
 
         mirror_dir_name = os.path.dirname(mirror_file_name)
         if not os.path.isdir(mirror_dir_name):
             os.makedirs(mirror_dir_name)
-            # 
-            # set permissions of this new directory as per that of the directory that the flac file is in
-            #
             flac_file_dir = os.path.dirname(os.path.abspath(flac_file))
             os.chown(mirror_dir_name, os.stat(flac_file_dir).st_uid, os.stat(flac_file_dir).st_gid)
-            perms = os.stat(flac_file_dir).st_mode & 0o777
-            os.chmod(mirror_dir_name, perms)
-            
-        mirror_command = ['/usr/bin/ffmpeg', '-i', flac_file]
+            os.chmod(mirror_dir_name, os.stat(flac_file_dir).st_mode & 0o777)
+
+        # Added -hide_banner and -loglevel error
+        mirror_command = ['/usr/bin/ffmpeg', '-hide_banner', '-loglevel', 'error', '-i', flac_file]
         mirror_command = mirror_command + mirror_format['OPTIONS']
         mirror_command.append(mirror_file_name)
-        #
-        # Convert the file, if there is an error then display
-        # stdout/stderr from the subprocess.
-        #
+        
         result = subprocess.run(mirror_command, capture_output=True)
-        if os.path.isfile(mirror_file_name):
-            #
-            # Set the permissions of the newly mirrored file to be the same as the 
-            # flac file.
-            #
-            # Docker setup currently doesn't give the use permission to do this.
-            os.chown(mirror_file_name, os.stat(flac_file).st_uid, os.stat(flac_file).st_gid)
-            perms = os.stat(flac_file).st_mode & 0o777
-            os.chmod(mirror_file_name, perms)
 
         if result.returncode == 0:
-            print ("Created {}".format(mirror_file_name))
+            if os.path.isfile(mirror_file_name):
+                os.chown(mirror_file_name, os.stat(flac_file).st_uid, os.stat(flac_file).st_gid)
+                os.chmod(mirror_file_name, os.stat(flac_file).st_mode & 0o777)
             return 'MIRRORED'
         else:
-            print ("Error creating {}".format(mirror_file_name), file=sys.stderr)
-            print (result.stdout)
-            print (result.stderr, file=sys.stderr)
+            print(f"Error creating {mirror_file_name}", file=sys.stderr)
+            if result.stderr:
+                print(result.stderr.decode(), file=sys.stderr)
             return 'ERROR'
-            
-    else:
-        return 'EXISTS'
 
-#
-# Mark a directory as sync'ed. Probably should avoid doing it more than once,
-# but MVP.
-#
-def mark_directory_synced(mirror_dir_name)
-    with open(join([mirror_dir_name, '_synced'],'/') , 'w') as file:
-        file.write(datetime.datetime.now().strftime("%d-%b-%Y (%H:%M:%S.%f)"))
+    return 'EXISTS'
 
-#
-# Scan the FLAC_DIR looking for flac files to mirror.
-#
 def scan_flac_dir():
-    print("Scanning {}".format(flac_dir))
-    counts = {'FLAC':0}
+    counts = {'FLAC': 0}
     start_time = time.time()
     for (dirpath, dirnames, filenames) in walk(flac_dir):
+        # Skip hidden directories
+        dirnames[:] = [d for d in dirnames if not d.startswith('.')]
         for f in filenames:
-            if f.endswith('.flac'):
+            if f.endswith('.flac') and not f.startswith('._'):
                 counts['FLAC'] += 1
                 flac_file = os.path.join(dirpath, f)
-                
+
                 for mirror_format in mirror_formats:
                     rc = check_mirror_status(flac_file, format_options[mirror_format])
-                    cc = "{}_{}".format(mirror_format, rc)
-                    if cc not in counts:
-                        counts[cc] = 0
-                    counts[cc] += 1
-    print ("    Scanned {} flac files in {:6.3f} seconds".format(counts['FLAC'], time.time() - start_time))
-    for mirror_format in mirror_formats:
-        print ("    {} : {}".format(mirror_format, format_options[mirror_format]['DIR']))
-        for c in ['MIRRORED', 'ERROR', 'EXISTS']:
-            print ("        {:<8} : {}".format(c, counts.get("{}_{}".format(mirror_format, c), 0)))
+                    cc = f"{mirror_format}_{rc}"
+                    counts[cc] = counts.get(cc, 0) + 1
 
-
-
-
+    # Clean Heartbeat Output
+    tasks = [f"{m}: {counts.get(m+'_MIRRORED',0)} new, {counts.get(m+'_ERROR',0)} err" for m in mirror_formats]
+    print(f"Heartbeat: Scanned {counts['FLAC']} files in {time.time() - start_time:.2f}s. Tasks: {', '.join(tasks)}", flush=True)
 
 if __name__ == "__main__":
-    print("Environment:")
-    print(environ)
-    #
-    # Check what, if any formats are required to be mirrored
-    #
-    mirror_formats = environ.get('MIRROR', '').strip().split(',')
-    if mirror_formats[0] == '':
-        mirror_formats.pop()
-    if len(mirror_formats) == 0:
-        print ("No formats to mirror to specified - nothing to do", flush=True)
+    mirror_formats = [m for m in environ.get('MIRROR', '').strip().split(',') if m]
+    if not mirror_formats:
+        print("No formats to mirror specified", flush=True)
         sys.exit(1)
-        
-    #
-    # Check flac dir is good, can't do much if it isn't set
-    #
+
     flac_dir = environ.get('FLAC_DIR', '/flac')
-    if not os.path.isdir(flac_dir):
-        print("FLAC_DIR '{}' is not an accessible directory".format(flac_dir), file=sys.stderr)
-        sys.exit(1)
-
-
-    #
-    # Default options
-    #
+    
     format_options = {
-        'M4A': {
-            'OPTIONS':'-c:a aac -b:a 192k -vn', 
-            'DIR': '/m4a',
-            'EXT': 'm4a'
-              
-            },
-        'MP3': { 
-            'OPTIONS':'-c:a mp3 -ab 192k -map_metadata 0', 
-            'DIR':'/mp3',
-            'EXT':'mp3'
-            },
-        'OGG': { 
-            'OPTIONS':'-c:a libvorbis',
-            'DIR': '/ogg',
-            'EXT':'ogg'
-            }
-        }
+        'M4A': {'OPTIONS':'-c:a aac -b:a 192k -vn', 'DIR': '/m4a', 'EXT': 'm4a'},
+        'MP3': {'OPTIONS':'-c:a mp3 -ab 192k -map_metadata 0', 'DIR':'/mp3', 'EXT':'mp3'},
+        'OGG': {'OPTIONS':'-c:a libvorbis', 'DIR': '/ogg', 'EXT':'ogg'}
+    }
 
-    #
-    # See if anything has been over-ridden with environment variables
-    #
-    for fmat in format_options:
-        ev = "{}_DIR".format(fmat)
-        if ev in os.environ:
-            ed = environ.get(ev) 
-            if not os.path.isdir(ed):
-                print("{}={} is not an accessible directory".format(ev, ed), file=sys.stderr, flush=True)
-            else:
-                format_options[fmat]['DIR'] = environ.get(ev) 
-        eo = "{}_OPTIONS".format(fmat)
-        if eo in os.environ:
-            format_options[fmat]['OPTIONS'] = environ.get(eo) 
-        format_options[fmat]['OPTIONS'] = format_options[fmat]['OPTIONS'].split(' ')
-    
-    #
-    # Print the config
-    #
-    print ("flac-mirror")
-    for fmat in format_options:
-        if fmat not in mirror_formats:
-            print ("    {} - not enabled".format(fmat))
-        else:
-            print ("    {}".format(fmat))
-            print ("         DIR : {}".format(format_options[fmat]["DIR"]))
-            print ("         EXT : {}".format(format_options[fmat]["EXT"]))
-            print ("         OPTIONS : {}".format(format_options[fmat]["OPTIONS"]))
-    print(flush=True)        
-    
+    for fmat in mirror_formats:
+        if fmat in format_options:
+            ev_dir = f"{fmat}_DIR"
+            if ev_dir in environ:
+                format_options[fmat]['DIR'] = environ[ev_dir]
             
-    #
-    # Scan the flac dir looking for work.  Wait a minute before scanning again.
-    #
-    sleep_time = 60
-    while (True):
-        if len(mirror_formats) == 0:
-            break
+            ev_opt = f"{fmat}_OPTIONS"
+            if ev_opt in environ:
+                format_options[fmat]['OPTIONS'] = environ[ev_opt]
+            
+            format_options[fmat]['OPTIONS'] = format_options[fmat]['OPTIONS'].split()
+
+    print(f"flac-mirror started for formats: {', '.join(mirror_formats)}", flush=True)
+
+    while True:
         scan_flac_dir()
-        print ("Sleeping for {} seconds before re-scanning".format(sleep_time), flush=True)
-        time.sleep(sleep_time)
+        time.sleep(60)

--- a/flac-mirror/mirror.py
+++ b/flac-mirror/mirror.py
@@ -74,6 +74,7 @@ def check_mirror_status(flac_file, mirror_format):
             # Set the permissions of the newly mirrored file to be the same as the 
             # flac file.
             #
+            # Docker setup currently doesn't give the use permission to do this.
             os.chown(mirror_file_name, os.stat(flac_file).st_uid, os.stat(flac_file).st_gid)
             perms = os.stat(flac_file).st_mode & 0o777
             os.chmod(mirror_file_name, perms)
@@ -89,6 +90,14 @@ def check_mirror_status(flac_file, mirror_format):
             
     else:
         return 'EXISTS'
+
+#
+# Mark a directory as sync'ed. Probably should avoid doing it more than once,
+# but MVP.
+#
+def mark_directory_synced(mirror_dir_name)
+    with open(join([mirror_dir_name, '_synced'],'/') , 'w') as file:
+        file.write(datetime.datetime.now().strftime("%d-%b-%Y (%H:%M:%S.%f)"))
 
 #
 # Scan the FLAC_DIR looking for flac files to mirror.

--- a/tools/verify_test_override.py
+++ b/tools/verify_test_override.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Fail if docker-compose.test.yml drifts beyond approved overrides."""
+from pathlib import Path
+import re
+import sys
+
+path = Path("docker-compose.test.yml")
+if not path.exists():
+    print("ERROR: docker-compose.test.yml not found")
+    sys.exit(1)
+
+text = path.read_text()
+
+forbidden = [
+    r"\bimage\s*:",
+    r"\bbuild\s*:",
+    r"\benvironment\s*:",
+    r"\bports\s*:",
+    r"\bdevices\s*:",
+    r"\bextra_hosts\s*:",
+    r"\bnetwork_mode\s*:",
+    r"\brestart\s*:",
+    r"\buser\s*:",
+    r"\bhostname\s*:",
+]
+for pat in forbidden:
+    if re.search(pat, text):
+        print(f"ERROR: forbidden key in docker-compose.test.yml: /{pat}/")
+        sys.exit(1)
+
+allowed_services = {"ripper", "flac_mirror"}
+services = set(re.findall(r"^  ([a-zA-Z0-9_-]+):\s*$", text, re.MULTILINE))
+extra_services = services - allowed_services
+if extra_services:
+    print("ERROR: unexpected service(s) in test override:", ", ".join(sorted(extra_services)))
+    sys.exit(1)
+
+if re.search(r"^\s*lms:\s*$", text, re.MULTILINE):
+    print("ERROR: lms overrides are not allowed in docker-compose.test.yml")
+    sys.exit(1)
+
+if "TEST_MUSIC_ROOT" not in text:
+    print("ERROR: TEST_MUSIC_ROOT is required in docker-compose.test.yml")
+    sys.exit(1)
+
+# Require every volume line in the override to use TEST_MUSIC_ROOT.
+for line in text.splitlines():
+    if re.match(r"^\s*-\s*", line) and ":/" in line:
+        if "TEST_MUSIC_ROOT" not in line:
+            print("ERROR: volume override line must use TEST_MUSIC_ROOT:")
+            print("  " + line)
+            sys.exit(1)
+
+print("OK: docker-compose.test.yml only changes approved ripper/mirror test volume paths.")

--- a/yar/Dockerfile
+++ b/yar/Dockerfile
@@ -1,7 +1,8 @@
 #
 # Use the latest ubuntu, which is currently 20.04
 #
-FROM ubuntu:latest
+# Testing with upgrade to last-known-good
+FROM ubuntu:24.04
 MAINTAINER 48clyde
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -9,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Get the required extras and clean up
 #
 RUN apt-get update -y && \
-  apt-get install -qy abcde cdparanoia eject flac netcat setcd sdparm eyed3 lame cd-discid && \
+  apt-get install -qy abcde cdparanoia eject flac netcat-openbsd setcd sdparm eyed3 lame cd-discid && \
   apt-get remove -qy postfix && \
   apt-get -qy clean && \
   apt-get -qy purge && \

--- a/yar/abcde-local.conf
+++ b/yar/abcde-local.conf
@@ -340,7 +340,8 @@
 # The variable CDPARANOIOPTS is also used by GNU's cd-paranoia,
 # so use this when setting CDROMREADERSYNTX=libcdio.
 #CDPARANOIAOPTS=
-#CDDA2WAVOPTS=
+# Based on https://ubuntuforums.org/archive/index.php/t-1568620.html
+CDDA2WAVOPTS="-paranoia -paraopts=proof"
 #PIRDOPTS="-p"
 # Options for the CD ripper dagrab can be seen by running 'dagrab -h'.
 # A good option to experiment with is the 'sectors per request' setting


### PR DESCRIPTION
## Summary
Stack of work for **YAR/abcde** (dirty / problematic discs), **flac-mirror** (stalling, logging, clearer transcode errors), a small **`.env` / crontab** note, and **`extra_hosts` in compose** (documented) so the stack resolves hostnames predictably. **Rebased onto current `master`** and resolved conflicts so **`docker-compose.yml` keeps `MUSIC_ROOT` mounts** and the current commented-Samba block from master.

`issue/add_sync_file_to_avoid_mp3_scans_from_configure_samba` was a **strict ancestor** of this branch (2 commits) and is **redundant**; that remote branch has been **deleted**. All of that work is included here (6 commits).

## Commits (newest first)
- Document why `extra_hosts` was needed in `docker-compose.yml`
- More specific transcode error reporting in `flac-mirror/mirror.py`
- Stalling mirror / YAR build adjustments: `mirror.py` + `yar/Dockerfile`
- Tolerate running under crontab (`.env`)
- "Way-too-chatty" flac-mirror + related compose (merged with `MUSIC_ROOT` on rebase)
- Abcde options to handle dirty discs: `yar/abcde-local.conf`

## Testing
- [ ] **newsounds only:** pull this branch, `docker compose up -d --build` for `ripper` and `flac_mirror` as needed, confirm no LMS state regression (separate from this PR if risky).
- [ ] Insert a test disc / observe mirror + ripper behavior per your environment.

## Notes
- Rebase conflict in `docker-compose.yml` was resolved in favor of **`MUSIC_ROOT:-/home/rec/Music`** and **`flac_mirror` `user: 1000:1000`**, not the old `${USER}` paths or `user: 0:0` from the historic commit.

Made with [Cursor](https://cursor.com)